### PR TITLE
Update username field in message payload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ client.on('messageCreate', async (message) => {
       },
       body: JSON.stringify({
         content: message.content,
-        username: message.author.tag,
+        username: message.author.username,
         avatar_url: message.author.displayAvatarURL(),
         flags: 4100,
       }),


### PR DESCRIPTION
This pull request updates the username field in the message payload from using the author's tag to using the author's username. This ensures that the correct username is displayed when sending messages.