### PR TITLE
Update .gitignore to use 'dest' instead of 'dist'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-dist/
+dest/
 coverage/
 
 .env


### PR DESCRIPTION
This pull request updates the .gitignore file to use 'dest' instead of 'dist' for the ignored directory. This change ensures that the correct directory is ignored and aligns with the project's conventions.