### PR TITLE
Refactor handleMessageCreate to handle message replies and add sasudai reaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,14 @@ export const handleMessageCreate =
       sasudaiReaction(message);
     }
 
+    if (message.reference?.messageId) {
+      const repliedMessage = await message.fetchReference();
+      if (message.content === '!daihyo') {
+        message.delete();
+        sasudaiReaction(repliedMessage);
+      }
+    }
+
     if (message.content === '!sasudai') {
       message.reply('https://x.com/STECH_FES/status/1773995315420631265');
       sasudaiReaction(message);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -115,6 +115,19 @@ describe('handleMessageCreate', () => {
     expect(mockDelete).not.toHaveBeenCalled();
   });
 
+  it('should delete the message and react to the replied message if the command is used', async () => {
+    const message = createMockMessage({
+      content: '!daihyo',
+      channelType: ChannelType.GuildText,
+      hasReference: true,
+    });
+
+    await handleMessageCreateCurried(message);
+
+    expect(mockDelete).toHaveBeenCalled();
+    expectReactionsToHaveBeenCalled(mockReact);
+  });
+
   it('replies with a specific URL and reacts when the message content is "!sasudai"', async () => {
     const message = createMockMessage({
       content: '!sasudai',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,12 +38,31 @@ describe('handleMessageCreate', () => {
     channelType,
     isBot = false,
     isMentionedMe = false,
+    hasReference = false,
   }: {
     content: string;
     channelType: ChannelType;
     isBot?: boolean;
     isMentionedMe?: boolean;
+    hasReference?: boolean;
   }) => {
+    const fetchReference = hasReference
+      ? jest.fn().mockResolvedValue(
+          createMockMessage({
+            content: '',
+            channelType: ChannelType.GuildText,
+          }),
+        )
+      : undefined;
+
+    const reference = hasReference
+      ? {
+          messageId: '1223834970863177769',
+          channelId: '1223834970863177769',
+          guildId: '1223834970863177769',
+        }
+      : undefined;
+
     return {
       content,
       author: { bot: isBot, displayAvatarURL: mockDisplayAvatarURL },
@@ -52,6 +71,8 @@ describe('handleMessageCreate', () => {
       reply: mockReply,
       mentions: { users: { has: () => isMentionedMe } },
       delete: mockDelete,
+      fetchReference: fetchReference,
+      reference: reference,
     } as unknown as Message;
   };
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,6 +29,7 @@ describe('handleMessageCreate', () => {
   const mockReact = jest.fn();
   const mockReply = jest.fn();
   const mockDisplayAvatarURL = jest.fn();
+  const mockDelete = jest.fn();
   const client = { user: {} } as unknown as Client;
   const handleMessageCreateCurried = handleMessageCreate(client);
 
@@ -50,6 +51,7 @@ describe('handleMessageCreate', () => {
       react: mockReact,
       reply: mockReply,
       mentions: { users: { has: () => isMentionedMe } },
+      delete: mockDelete,
     } as unknown as Message;
   };
 
@@ -72,6 +74,7 @@ describe('handleMessageCreate', () => {
     }
 
     expect(mockReply).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('should react with specific emojis when content includes "代表"', async () => {
@@ -87,6 +90,8 @@ describe('handleMessageCreate', () => {
       expect(fetch).not.toHaveBeenCalled();
     }
     expectReactionsToHaveBeenCalled(mockReact);
+
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('replies with a specific URL and reacts when the message content is "!sasudai"', async () => {
@@ -103,6 +108,7 @@ describe('handleMessageCreate', () => {
     expectReactionsToHaveBeenCalled(mockReact);
 
     expect(fetch).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('should reply to direct messages if not from a bot', async () => {
@@ -121,6 +127,8 @@ describe('handleMessageCreate', () => {
     expect(mockReply).toHaveBeenCalledWith(
       process.env.DM_MESSAGE_CONTENT ?? '',
     );
+
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('should not reply if the message author is a bot', async () => {
@@ -135,6 +143,7 @@ describe('handleMessageCreate', () => {
     expect(mockReply).not.toHaveBeenCalled();
 
     expect(fetch).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('should reply to mentions if not from a bot', async () => {
@@ -151,6 +160,7 @@ describe('handleMessageCreate', () => {
     );
 
     expect(fetch).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('should use default empty string if DM_MESSAGE_CONTENT is not defined', async () => {
@@ -164,6 +174,8 @@ describe('handleMessageCreate', () => {
     await handleMessageCreateCurried(message);
 
     expect(mockReply).toHaveBeenCalledWith('');
+
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('should use default empty string if MENTION_MESSAGE_CONTENT is not defined', async () => {
@@ -179,5 +191,7 @@ describe('handleMessageCreate', () => {
     await handleMessageCreateCurried(message);
 
     expect(mockReply).toHaveBeenCalledWith('');
+
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This pull request refactors the handleMessageCreate function in the index.ts file to handle message replies and adds a sasudai reaction. The sasudaiReaction function is also added to handle reacting to messages with the sasudai emoji.